### PR TITLE
fix: empty editor group renders darker than the editor background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## 3.20.2 | 2026.08.13
+- Fix the empty editor area being noticeably darker than the editor background
+- Regenerate the Mix and Night Flat themes when settings change
+
 ## 3.20.1 | 2026.08.13
 - Upgrade CD to Node 24
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-theme",
   "displayName": "One Dark Pro",
   "description": "Atom's iconic One Dark theme for Visual Studio Code",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "publisher": "zhuangtongfa",
   "license": "MIT",
   "bugs": {

--- a/src/themes/data/oneDarkPro.ts
+++ b/src/themes/data/oneDarkPro.ts
@@ -37,7 +37,7 @@ export default withModernUiTokens({
   'editorCursor.background': '#ffffffc9',
   'editorCursor.foreground': '#528bff',
   'editorError.foreground': '#c24038',
-  'editorGroup.emptyBackground': '#181a1f',
+  'editorGroup.emptyBackground': '#282c34',
   'editorGroup.border': '#181a1f',
   'editorGroupHeader.tabsBackground': '#21252b',
   'editorGutter.addedBackground': '#109868',

--- a/src/themes/data/oneDarkProDarker.ts
+++ b/src/themes/data/oneDarkProDarker.ts
@@ -37,7 +37,7 @@ export default withModernUiTokens({
   'editorCursor.background': '#ffffffc9',
   'editorCursor.foreground': '#528bff',
   'editorError.foreground': '#c24038',
-  'editorGroup.emptyBackground': '#181a1f',
+  'editorGroup.emptyBackground': '#23272e',
   'editorGroup.border': '#181a1f',
   'editorGroupHeader.tabsBackground': '#1e2227',
   'editorGutter.addedBackground': '#109868',

--- a/src/themes/data/oneDarkProMix.ts
+++ b/src/themes/data/oneDarkProMix.ts
@@ -37,7 +37,7 @@ export default withModernUiTokens({
   'editorCursor.background': '#ffffffc9',
   'editorCursor.foreground': '#528bff',
   'editorError.foreground': '#c24038',
-  'editorGroup.emptyBackground': '#181a1f',
+  'editorGroup.emptyBackground': '#282c34',
   'editorGroup.border': '#181a1f',
   'editorGroupHeader.tabsBackground': '#21252b',
   'editorGutter.addedBackground': '#109868',

--- a/src/themes/data/oneDarkProNightFlat.ts
+++ b/src/themes/data/oneDarkProNightFlat.ts
@@ -37,7 +37,7 @@ export default withModernUiTokens({
   'editorCursor.background': '#ffffffc9',
   'editorCursor.foreground': '#528bff',
   'editorError.foreground': '#c24038',
-  'editorGroup.emptyBackground': '#181a1f',
+  'editorGroup.emptyBackground': '#16191d',
   'editorGroup.border': '#181a1f',
   'editorGroupHeader.tabsBackground': '#16191d',
   'editorGutter.addedBackground': '#109868',

--- a/src/utils/updateTheme.ts
+++ b/src/utils/updateTheme.ts
@@ -19,6 +19,8 @@ export async function updateTheme() {
     writeTheme('OneDark-Pro.json'),
     writeTheme('OneDark-Pro-flat.json', 'One Dark Pro Flat'),
     writeTheme('OneDark-Pro-darker.json', 'One Dark Pro Darker'),
+    writeTheme('OneDark-Pro-mix.json', 'One Dark Pro Mix'),
+    writeTheme('OneDark-Pro-night-flat.json', 'One Dark Pro Night Flat'),
   ]
   await Promise.all(promiseArr)
   promptToReload()

--- a/themes/OneDark-Pro-darker.json
+++ b/themes/OneDark-Pro-darker.json
@@ -2144,7 +2144,7 @@
     "editorCursor.background": "#ffffffc9",
     "editorCursor.foreground": "#528bff",
     "editorError.foreground": "#c24038",
-    "editorGroup.emptyBackground": "#181a1f",
+    "editorGroup.emptyBackground": "#23272e",
     "editorGroup.border": "#181a1f",
     "editorGroupHeader.tabsBackground": "#1e2227",
     "editorGutter.addedBackground": "#109868",

--- a/themes/OneDark-Pro-mix.json
+++ b/themes/OneDark-Pro-mix.json
@@ -2187,7 +2187,7 @@
     "editorCursor.background": "#ffffffc9",
     "editorCursor.foreground": "#528bff",
     "editorError.foreground": "#c24038",
-    "editorGroup.emptyBackground": "#181a1f",
+    "editorGroup.emptyBackground": "#282c34",
     "editorGroup.border": "#181a1f",
     "editorGroupHeader.tabsBackground": "#21252b",
     "editorGutter.addedBackground": "#109868",

--- a/themes/OneDark-Pro-night-flat.json
+++ b/themes/OneDark-Pro-night-flat.json
@@ -2144,7 +2144,7 @@
     "editorCursor.background": "#ffffffc9",
     "editorCursor.foreground": "#528bff",
     "editorError.foreground": "#c24038",
-    "editorGroup.emptyBackground": "#181a1f",
+    "editorGroup.emptyBackground": "#16191d",
     "editorGroup.border": "#181a1f",
     "editorGroupHeader.tabsBackground": "#16191d",
     "editorGutter.addedBackground": "#109868",

--- a/themes/OneDark-Pro.json
+++ b/themes/OneDark-Pro.json
@@ -2166,7 +2166,7 @@
     "editorCursor.background": "#ffffffc9",
     "editorCursor.foreground": "#528bff",
     "editorError.foreground": "#c24038",
-    "editorGroup.emptyBackground": "#181a1f",
+    "editorGroup.emptyBackground": "#282c34",
     "editorGroup.border": "#181a1f",
     "editorGroupHeader.tabsBackground": "#21252b",
     "editorGutter.addedBackground": "#109868",


### PR DESCRIPTION
## Problem

Since 3.20.0, the area shown when no file is open — the default/watermark page — renders noticeably darker than the surrounding editor, so the middle of the window reads as a black block that no longer lines up with the rest of the UI.

## Cause

`98a63df` ("update deprecated workbench color keys") renamed:

```diff
- 'editorGroup.background': '#181a1f',
+ 'editorGroup.emptyBackground': '#181a1f',
```

These two keys are not equivalent:

- `editorGroup.background` no longer exists in VS Code's color registry at all (it isn't registered in `vs/workbench/common/theme.ts`). The `#181a1f` value had been dead for years, so the empty editor group simply fell back to `editor.background`.
- `editorGroup.emptyBackground` **is** live, and defaults to `null` (i.e. falls back to `editor.background`). It is exactly the background of an empty editor group.

So the rename promoted a dead value into a real color, and the empty editor group started painting `#181a1f` while the editor around it stayed at `#282c34`.

Four of the five variants were affected:

| Variant | `editor.background` | `emptyBackground` on 3.20.x | |
|---|---|---|---|
| One Dark Pro | `#282c34` | `#181a1f` | too dark |
| Darker | `#23272e` | `#181a1f` | too dark |
| Mix | `#282c34` | `#181a1f` | too dark |
| Night Flat | `#16191d` | `#181a1f` | too light |
| Flat | `#282c34` | `#282c34` | already correct |

Flat was untouched by the bug because that commit only *dropped* its dead `editorGroup.background` — it already carried a correct `editorGroup.emptyBackground`. That is the behaviour this PR restores for the other four.

## Changes

1. **`fix: align editorGroup.emptyBackground with editor.background`** — point the key at each variant's own `editor.background` and regenerate `themes/*.json`. The generated diff is one key per file, nothing else moved.
2. **`fix: regenerate Mix and Night Flat themes on settings change`** — `updateTheme()` only rewrote the default, Flat and Darker theme files, so changing any `oneDarkPro.*` setting (bold, italic, vivid, editorTheme, custom colors) left Mix and Night Flat stale. Unrelated to the color regression, but found while tracing it; happy to split it out if you'd prefer.
3. **`chore: 3.20.2`** — CHANGELOG entry and version bump. Feel free to drop this commit if you'd rather cut releases yourself.

## Verification

- `themes/*.json` regenerated with `scripts/generate-theme.ts`; the diff is exactly the four intended values.
- `npx eslint` clean, `tsc -p src --noEmit` clean.

## Workaround for users on 3.20.x

```json
"workbench.colorCustomizations": {
  "[One Dark Pro]": { "editorGroup.emptyBackground": "#282c34" },
  "[One Dark Pro Darker]": { "editorGroup.emptyBackground": "#23272e" },
  "[One Dark Pro Mix]": { "editorGroup.emptyBackground": "#282c34" },
  "[One Dark Pro Night Flat]": { "editorGroup.emptyBackground": "#16191d" }
}
```
